### PR TITLE
Peg version numbers for dependencies

### DIFF
--- a/nacc_utils/nacculator_runner/Dockerfile
+++ b/nacc_utils/nacculator_runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-chrome:latest
+FROM selenium/node-chrome:3.14.0-europium
 
 USER root
 

--- a/nacc_utils/nacculator_runner/Dockerfile
+++ b/nacc_utils/nacculator_runner/Dockerfile
@@ -2,7 +2,7 @@ FROM selenium/node-chrome:3.14.0-europium
 
 USER root
 
-ENV DISPLAY ":99.0" 
+ENV DISPLAY ":99.0"
 RUN rm -rf /etc/apt/sources.list
 RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial main restricted universe multiverse" >> /etc/apt/sources.list
 RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-updates main restricted universe multiverse" >> /etc/apt/sources.list
@@ -10,7 +10,7 @@ RUN echo "deb-src mirror://mirrors.ubuntu.com/mirrors.txt xenial-updates main re
 RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-backports main restricted universe multiverse" >> /etc/apt/sources.list
 RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-security main restricted universe multiverse" >> /etc/apt/sources.list
 RUN apt update && apt-get -y install python2.7 python-pip git
-RUN apt-get clean && apt-get update 
+RUN apt-get clean && apt-get update
 COPY nacculator_runner/ /nacc_utils/
 COPY nacc_automation/sel.py nacc_automation/packet_config_example.ini nacc_automation/getpacket.js nacc_automation/send_email.py nacc_automation/smtp_config_example.ini /nacc_utils/
 

--- a/nacc_utils/nacculator_runner/Dockerfile
+++ b/nacc_utils/nacculator_runner/Dockerfile
@@ -3,12 +3,6 @@ FROM selenium/node-chrome:3.14.0-europium
 USER root
 
 ENV DISPLAY ":99.0"
-RUN rm -rf /etc/apt/sources.list
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial main restricted universe multiverse" >> /etc/apt/sources.list
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-updates main restricted universe multiverse" >> /etc/apt/sources.list
-RUN echo "deb-src mirror://mirrors.ubuntu.com/mirrors.txt xenial-updates main restricted universe multiverse" >> /etc/apt/sources.list
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-backports main restricted universe multiverse" >> /etc/apt/sources.list
-RUN echo "deb mirror://mirrors.ubuntu.com/mirrors.txt xenial-security main restricted universe multiverse" >> /etc/apt/sources.list
 RUN apt update && apt-get -y install python2.7 python-pip git
 RUN apt-get clean && apt-get update
 COPY nacculator_runner/ /nacc_utils/

--- a/nacc_utils/nacculator_runner/Dockerfile
+++ b/nacc_utils/nacculator_runner/Dockerfile
@@ -17,11 +17,9 @@ COPY nacc_automation/sel.py nacc_automation/packet_config_example.ini nacc_autom
 WORKDIR /nacc_utils
 RUN chmod u+x run.sh
 
-RUN apt-get -y install scrot
-RUN apt-get -y install python-tk
-RUN apt-get -y install python-dev
-RUN pip install --upgrade pip; hash -r pip;
-RUN pip install pdfminer python-xlib selenium jinja2
+RUN apt-get -y install scrot python-tk python-dev
+RUN pip install --upgrade pip; hash -r pip
+RUN pip install pdfminer==20140328 python-xlib==0.25 selenium==3.141.0 jinja2==2.10.1
 RUN pip install git+https://github.com/ctsit/nacculator.git git+https://github.com/ctsit/cappy.git
 RUN xvfb-run pip install pyautogui==0.9.39
 

--- a/nacc_utils/nacculator_runner/Dockerfile
+++ b/nacc_utils/nacculator_runner/Dockerfile
@@ -4,17 +4,14 @@ USER root
 
 ENV DISPLAY ":99.0"
 RUN apt update && apt-get -y install python2.7 python-pip git
-RUN apt-get clean && apt-get update
 COPY nacculator_runner/ /nacc_utils/
 COPY nacc_automation/sel.py nacc_automation/packet_config_example.ini nacc_automation/getpacket.js nacc_automation/send_email.py nacc_automation/smtp_config_example.ini /nacc_utils/
-
-WORKDIR /nacc_utils
-RUN chmod u+x run.sh
 
 RUN apt-get -y install scrot python-tk python-dev
 RUN pip install --upgrade pip; hash -r pip
 RUN pip install pdfminer==20140328 python-xlib==0.25 selenium==3.141.0 jinja2==2.10.1
-RUN pip install git+https://github.com/ctsit/nacculator.git git+https://github.com/ctsit/cappy.git
 RUN xvfb-run pip install pyautogui==0.9.39
+RUN pip install git+https://github.com/ctsit/nacculator.git git+https://github.com/ctsit/cappy.git
 
-ENTRYPOINT ["/bin/bash", "-c", "./run.sh", "getdata"]
+WORKDIR /nacc_utils
+ENTRYPOINT ["/bin/bash", "./run.sh"]

--- a/nacc_utils/nacculator_runner/Dockerfile
+++ b/nacc_utils/nacculator_runner/Dockerfile
@@ -23,6 +23,6 @@ RUN apt-get -y install python-dev
 RUN pip install --upgrade pip; hash -r pip;
 RUN pip install pdfminer python-xlib selenium jinja2
 RUN pip install git+https://github.com/ctsit/nacculator.git git+https://github.com/ctsit/cappy.git
-RUN xvfb-run pip install pyautogui
+RUN xvfb-run pip install pyautogui==0.9.39
 
 ENTRYPOINT ["/bin/bash", "-c", "./run.sh", "getdata"]


### PR DESCRIPTION
Since we weren't specifying a fixed version number to use, updates have broken our build process. I've added version numbers for all PIP packages as well as the Docker Image and tested the build process after removing all my images and containers.